### PR TITLE
Corrected example for ⎕IO=1 on page /SystemFunctions.html 

### DIFF
--- a/contents/_build/html/SystemFunctions.html
+++ b/contents/_build/html/SystemFunctions.html
@@ -461,7 +461,7 @@
 </div>
 <div class="cell_output docutils container">
 <div class="output text_html"><span style="white-space:pre; font-family: monospace">0 1 2 3
-</span></div><div class="output text_html"><span style="white-space:pre; font-family: monospace">0 1 2 3
+</span></div><div class="output text_html"><span style="white-space:pre; font-family: monospace">1 2 3 4
 </span></div></div>
 </div>
 <p>Note that using <code class="docutils literal notranslate"><span class="pre">⎕IO←0</span></code> means you have to accept negative indices in some cases:</p>


### PR DESCRIPTION
Hey @xpqz I have made the changes in SystemFunctions.html and rerun it also. Its all looking fine now.
Please review this PR.
Thanks!